### PR TITLE
fix: 解决popup mask绝对定位在滚动页面中的bug

### DIFF
--- a/src/popup/index.acss
+++ b/src/popup/index.acss
@@ -3,7 +3,7 @@
 }
 
 .am-popup-mask {
-  position: absolute;
+  position: fixed;
   top: 0;
   bottom: 0;
   left: 0;


### PR DESCRIPTION
fix: 解决popup mask绝对定位在滚动页面中的bug