### PR TITLE
bump 0.3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.3.12
+
+`2018-10-12`
+
+- **Enhancement**
+  - `vtabs`新增`badgeType`和`badgeText`属性([#92](https://github.com/ant-mini-program/mini-antui/issues/92))
+
 ## 0.3.11
 
 `2018-10-10`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mini-antui",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "小程序版AntUI",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- **Enhancement**
  - `vtabs`新增`badgeType`和`badgeText`属性([#92](https://github.com/ant-mini-program/mini-antui/issues/92))