### PR TITLE
bugfix:ios9下height设置为100%会导致background-image无法显示

### DIFF
--- a/src/notice/index.acss
+++ b/src/notice/index.acss
@@ -61,7 +61,7 @@
 
 .am-notice-closable {
   width: 10px;
-  height: 100%;
+  height: 36px;
   background-image: url('https://gw.alipayobjects.com/zos/rmsportal/mLiemrUlPGVwIGXQdWDx.png');
   background-size: contain;
   background-position: center;


### PR DESCRIPTION
bugfix