### PR TITLE
release 0.4.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.4.27
+
+`2019-05-24`
+
+- **Bug Fix**
+  - 修复`collapse`无法在钉钉小程序上展开的问题([#272](https://github.com/ant-mini-program/mini-antui/issues/272))
+  - 修复`stepper` readOnly状态下按钮点击无效的问题
+
 ## 0.4.26
 
 `2019-05-10`
@@ -41,7 +49,7 @@
 `2019-03-22`
 
 - **Feature**
-  - 新增`collapase`组件
+  - 新增`collapse`组件
   - `grid`支持slot
 
 - **Enhancement**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mini-antui",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "description": "小程序版AntUI",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- **Bug Fix**
  - 修复`collapse`无法在钉钉小程序上展开的问题([#272](https://github.com/ant-mini-program/mini-antui/issues/272))
  - 修复`stepper` readOnly为状态下按钮点击无效的问题