### PR TITLE
chore: install dependencies before build

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
   },
   "scripts": {
     "lint-staged": "lint-staged",
-    "build": "NODE_ENV=production node scripts/compiler.js",
+    "build": "yarn && NODE_ENV=production node scripts/compiler.js",
     "pub": "npm run build && node scripts/pub.js",
-    "dev": "node scripts/compiler.js"
+    "dev": "yarn && node scripts/compiler.js"
   },
   "pre-commit": [
     "lint-staged"


### PR DESCRIPTION
install dependencies before build