### PR TITLE
fix: Searchbar clear button not work on long placeholder

### DIFF
--- a/components/search-bar/index.less
+++ b/components/search-bar/index.less
@@ -27,7 +27,6 @@
   }
 
   &-synthetic-placeholder {
-    width: 100px;
     font-size: 14px;
     color: #999;
   }
@@ -52,6 +51,7 @@
   }
 
   &-clear {
+    position: relative;
     visibility: hidden;
     width: 28px;
     height: 28px;


### PR DESCRIPTION
Searchbar clear button not work on long placeholder