### PR TITLE
fix: clear collapse cache in page when didUnmount

### DIFF
--- a/components/collapse/index.ts
+++ b/components/collapse/index.ts
@@ -22,6 +22,12 @@ Component({
     this.initData();
   },
 
+  didUnmount() {
+    // clear cache in page when didUnmount
+    delete this.$page[collapsePrefix(`ids-${this.props.collapseKey}`)];
+    delete this.$page[collapsePrefix(`updates-${this.props.collapseKey}`)];
+  },
+
   methods: {
     initData() {
       const { accordion, activeKey, collapseKey } = this.props;


### PR DESCRIPTION
clear collapse cache in page when didUnmount.
`<collapse a:if={{condition}}>`
If condition become false, collapse will unmounted, but cache of collapse still in page. This will cause setData to unmount Component when condition become true.